### PR TITLE
Drop support for Python 2.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - 2.6
     - 2.7
 install:
     - pip install .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@
 CHANGES
 =======
 
-4.0.1 (unreleased)
+5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop support for Python 2.6.
 
 
 4.0.0 (2013-02-12)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
 setup(name='zope.untrustedpython',
-      version='4.0.1.dev0',
+      version='5.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Untrusted Python Library',
@@ -43,7 +43,6 @@ setup(name='zope.untrustedpython',
           'License :: OSI Approved :: Zope Public License',
           'Programming Language :: Python',
           'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: Implementation :: CPython',
           'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,docs,coverage
+envlist = py27,docs,coverage
 
 [testenv]
 commands =
@@ -27,7 +27,7 @@ deps =
 
 [testenv:docs]
 basepython =
-    python2.6
+    python2.7
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest


### PR DESCRIPTION
- bumped to new major version as Centos 6 still supports Python 2.6.

modified:   .travis.yml
modified:   CHANGES.rst
modified:   setup.py
modified:   tox.ini