### PR TITLE
Make tests aware of PyPy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ CHANGES
 
 - Drop support for Python 2.7, 3.5, 3.6.
 
+- Make sure the tests do not fail even on unsupported PyPy3 because ZTK might
+  run them.
+
 
 5.0 (2022-11-29)
 ----------------

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -365,7 +365,10 @@ All of the non-basic items in the safe builtins are proxied:
 
    >>> exec_src('str=str', d)
    >>> from zope.security.proxy import Proxy
-   >>> type(d['str']) is Proxy
+   >>> import platform
+   >>> IS_PYPY = platform.python_implementation() == 'PyPy'
+   >>> # PyPy does not support proxies.
+   >>> True if IS_PYPY else type(d['str']) is Proxy
    True
 
 Note that you cannot get access to `__builtins__`:

--- a/src/zope/untrustedpython/tests.py
+++ b/src/zope/untrustedpython/tests.py
@@ -11,13 +11,14 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-import unittest
 import platform
+import unittest
 from io import StringIO
 
 from zope.untrustedpython import interpreter
 from zope.untrustedpython import rcompile
 from zope.untrustedpython.builtins import SafeBuiltins
+
 
 IS_PYPY = platform.python_implementation() == 'PyPy'
 

--- a/src/zope/untrustedpython/tests.py
+++ b/src/zope/untrustedpython/tests.py
@@ -22,6 +22,7 @@ from zope.untrustedpython.builtins import SafeBuiltins
 
 IS_PYPY = platform.python_implementation() == 'PyPy'
 
+
 class Test_SafeBuiltins(unittest.TestCase):
 
     def test_simple(self):

--- a/src/zope/untrustedpython/tests.py
+++ b/src/zope/untrustedpython/tests.py
@@ -12,12 +12,14 @@
 #
 ##############################################################################
 import unittest
+import platform
 from io import StringIO
 
 from zope.untrustedpython import interpreter
 from zope.untrustedpython import rcompile
 from zope.untrustedpython.builtins import SafeBuiltins
 
+IS_PYPY = platform.python_implementation() == 'PyPy'
 
 class Test_SafeBuiltins(unittest.TestCase):
 
@@ -73,6 +75,7 @@ class Test_Interpreter(unittest.TestCase):
         self.assertEqual(d['x'], 1)
         self.assertEqual(d['__builtins__'], SafeBuiltins)
 
+    @unittest.skipIf(IS_PYPY, 'PyPy does not support proxies.')
     def test_proxied(self):
         d = {}
         interpreter.exec_src('str=str', d)


### PR DESCRIPTION
PyPy is not supported but do not let the tests fail when running them as ZTK might do so.